### PR TITLE
Validate that the array's args isn't empty

### DIFF
--- a/commands/cfe.js
+++ b/commands/cfe.js
@@ -9,7 +9,7 @@ module.exports = {
   description: 'Get searching parameters from the user.',
   cooldown: 3,
   execute(message, args) {
-    if (!args) {
+    if (!args || args.length == 0) {
       return message.channel.send('The command needs a searching parameter.');
     }
     const route = `./assets/cfe_${args.join('').toLowerCase()}.json`;


### PR DESCRIPTION
The scrap was executed even if the args were empty.
I added a validation to verify if the array (where are saved the args), is empty.
If it is empty, the bot will send a message telling that to execute the scrap is needed a search parameter.