### PR TITLE
Close browser if the search doesn't have results

### DIFF
--- a/scrapperFunctions/index.js
+++ b/scrapperFunctions/index.js
@@ -148,7 +148,7 @@ ScrapPage.prototype.checkData = async function (
     const onlyNumbers = validateNumber.test(exp);
     typeof exp !== 'string' && onlyNumbers ? (exp = data.length) : exp;
     let obt = data.length;
-
+    if (exp == 0) return exp;
     console.log(`Expected data: ${exp}`);
     console.log(`Getting data...`);
 

--- a/webScraping/cfeScrapper.js
+++ b/webScraping/cfeScrapper.js
@@ -101,6 +101,12 @@ Scrapper.prototype.doScraping = async function (route) {
       // eslint-disable-next-line prettier/prettier
       this.printPercentage,
     );
+    if (data == 0) {
+      console.log('There is no data available');
+      await myPage.closeBrowser();
+      console.log('Browser closed successfully');
+      return;
+    }
     console.log(`Obtained data: ${data.length}`);
 
     const object = await data.map((item) =>


### PR DESCRIPTION
In this PR I added a validation in the scrapper, it will verify if the quantity of data expected is 0 and stop the process (closing the browser), else, it will follow the normal flow.